### PR TITLE
Move edit lock button to toolbar

### DIFF
--- a/frontend/app/components/PxComponents/PxChartComponents/PxChartCanvas.vue
+++ b/frontend/app/components/PxComponents/PxChartComponents/PxChartCanvas.vue
@@ -2,7 +2,6 @@
 import {
   type NodeDragEvent,
   VueFlow,
-  Panel,
   type Connection,
   type EdgeChange,
   type NodeChange,
@@ -473,10 +472,12 @@ async function handleEditSettings() {
 
   <PxChartToolbar
     :menu-snap-to-grid="menuSnapToGrid"
+    :single-edge-selected="getSelectedEdges.length === 1"
     @add-existing-node="handleAddContainerFromPanel(false, false)"
     @add-new-node="handleAddContainerFromPanel(true, false)"
     @toggle-snap-to-grid="handleToggleSnapToGrid()"
     @edit-settings="handleEditSettings()"
+    @edit-locks="handleEditLocks()"
   >
     <template #right>
       <!-- Context Strategy Analysis Button -->
@@ -604,17 +605,6 @@ async function handleEditSettings() {
         @update-px-node="(containerId, nodeId) => handleEditPxNode(containerId, nodeId)"
       />
     </template>
-
-    <Panel :position="'top-left'">
-      <!-- Edge-specific Action, only available when edge is selected -->
-      <UTooltip
-        v-if="getSelectedEdges.length === 1"
-        text="Add or Edit Locks"
-        :content="{ align: 'center', side: 'right' }"
-      >
-        <UButton size="xl" icon="i-lucide-lock" color="primary" @click="handleEditLocks" />
-      </UTooltip>
-    </Panel>
   </VueFlow>
 
   <!-- Context Strategy Slideover -->

--- a/frontend/app/components/PxComponents/PxChartComponents/PxChartToolbar.vue
+++ b/frontend/app/components/PxComponents/PxChartComponents/PxChartToolbar.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 const emit = defineEmits<{
-  (e: 'addNewNode' | 'addExistingNode' | 'toggleSnapToGrid' | 'editSettings'): void
+  (e: 'addNewNode' | 'addExistingNode' | 'toggleSnapToGrid' | 'editSettings' | 'editLocks'): void
 }>()
 
 const props = defineProps({
   menuSnapToGrid: Boolean,
+  singleEdgeSelected: Boolean,
 })
 
 const toolbarSnapToGrid = computed(() => props.menuSnapToGrid)
@@ -79,6 +80,15 @@ async function handleToggleSnapToGrid() {
         </UButton>
       </UTooltip>
       <USeparator orientation="vertical" class="h-10" size="sm" />
+      <!-- Edge-specific Action, only available when edge is selected -->
+      <UTooltip
+        v-if="singleEdgeSelected"
+        text="Add or Edit Locks"
+        :content="{ align: 'center', side: 'right' }"
+      >
+        <UButton size="xl" icon="i-lucide-lock" color="primary" @click="emit('editLocks')" />
+      </UTooltip>
+      <USeparator v-if="singleEdgeSelected" orientation="vertical" class="h-10" size="sm" />
     </div>
 
     <!-- Temporary Buttons -->

--- a/frontend/app/components/PxComponents/PxNodeCard.vue
+++ b/frontend/app/components/PxComponents/PxNodeCard.vue
@@ -21,7 +21,7 @@ const { toggleSubstep } = useProjectWorkflow()
 const { fetchById: fetchComponentById } = usePxComponents()
 const { fetchById: fetchPxKeyById } = usePxKeys()
 
-// TODO: clean up emits and figure out what "addForeign" is supposed to do
+// TODO: figure out what "addForeign" is supposed to do and clean up emits
 const emit = defineEmits<{
   (e: 'addForeignComponent' | 'addForeignKey', nodeId: string, componentId: string): void
   (e: 'addComponent' | 'addKey' | 'deleteKey'): void


### PR DESCRIPTION
# Description

This PR moves the "Add/Edit Lock" button from the in-canvas panel to the new toolbar and removes the `Panel` import as it is no longer needed.

## Type of change

- [x] Other: UI improvement (no additional functionality, not really a bug fix)

# How Has This Been Tested?

<img width="1109" height="632" alt="image" src="https://github.com/user-attachments/assets/3dbb1b55-61ab-4d13-bc8f-6af60a835805" />

- [x] button is now located in toolbar instead of canvas
- [x] button has descriptive tooltip
- [x] button functionality remains unchanged (clicking it opens the "Edit Locks on Edge" modal, editing locks works as expected)

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
