### PR TITLE
Implements version tag in frontend + release trigger workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,55 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version number (e.g. 1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  release:
+    name: Merge main to release, update version, and tag
+    runs-on: ubuntu-latest
+    if: contains(fromJSON(vars.ALLOWED_RELEASE_USERS || '["KuroiX"]'), github.actor)
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge main into release
+        run: |
+          git fetch origin main
+          git merge origin/main --no-edit
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Update version in package.json
+        run: |
+          npm version ${{ inputs.version }} --no-git-tag-version
+
+      - name: Commit version bump
+        run: |
+          git commit -am "chore(release): bump version to ${{ inputs.version }}"
+
+      - name: Push changes to release branch
+        run: |
+          git push origin release
+
+      - name: Create and push tag
+        run: |
+          git tag release/v${{ inputs.version }}
+          git push origin release/v${{ inputs.version }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -143,6 +143,12 @@ jobs:
             type=semver,pattern={{version}}
             type=ref,event=branch
             type=ref,event=pr
+      - name: Get version from root package.json
+        if: matrix.component == 'frontend' && needs[matrix.component].result == 'success'
+        id: get_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
       - name: Build image (push on main/release)
         if: needs[matrix.component].result == 'success'
         uses: docker/build-push-action@v7
@@ -150,3 +156,6 @@ jobs:
           context: ./${{ matrix.component }}
           push: ${{ github.ref_name == 'main' || github.ref_name == 'release' }}
           tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            NUXT_PUBLIC_VERSION=${{ steps.get_version.outputs.version }}
+            NUXT_PUBLIC_GIT_HASH=${{ github.sha }}

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -1,4 +1,4 @@
-name: Manual Release
+name: Trigger release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -3,8 +3,14 @@ name: Trigger release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'New version number (e.g. 1.0.0)'
+      release_version:
+        description: 'Release version number'
+        default: "1.0.0"
+        required: true
+        type: string
+      next_version:
+        description: 'Next version number'
+        default: "1.0.1-SNAPSHOT"
         required: true
         type: string
 
@@ -39,11 +45,11 @@ jobs:
 
       - name: Update version in package.json
         run: |
-          npm version ${{ inputs.version }} --no-git-tag-version
+          npm version ${{ inputs.release_version }} --no-git-tag-version
 
       - name: Commit version bump
         run: |
-          git commit -am "chore(release): bump version to ${{ inputs.version }}"
+          git commit -am "chore(release): bump version to ${{ inputs.release_version }}"
 
       - name: Push changes to release branch
         run: |
@@ -51,5 +57,21 @@ jobs:
 
       - name: Create and push tag
         run: |
-          git tag release/v${{ inputs.version }}
-          git push origin release/v${{ inputs.version }}
+          git tag release/v${{ inputs.release_version }}
+          git push origin release/v${{ inputs.release_version }}
+
+      - name: Checkout main branch
+        run: |
+          git checkout main
+
+      - name: Update version to next development version in package.json
+        run: |
+          npm version ${{ inputs.next_version }} --no-git-tag-version
+
+      - name: Commit next version bump
+        run: |
+          git commit -am "chore(main): bump version to ${{ inputs.next_version }}"
+
+      - name: Push changes to main branch
+        run: |
+          git push origin main

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,12 +8,17 @@ RUN npm install
 #                     Stage: Development (For local hot-reload support)                        #
 ################################################################################################
 FROM base AS development
+RUN apk add --no-cache git && git config --global --add safe.directory '*'
 CMD ["npm", "run", "dev"]
 
 ################################################################################################
 #                           Stage: Builder (For production stage)                              #
 ################################################################################################
 FROM base AS builder
+ARG NUXT_PUBLIC_VERSION
+ARG NUXT_PUBLIC_GIT_HASH
+ENV NUXT_PUBLIC_VERSION=$NUXT_PUBLIC_VERSION
+ENV NUXT_PUBLIC_GIT_HASH=$NUXT_PUBLIC_GIT_HASH
 COPY . .
 # CRITICAL: We use generate, NOT build, to produce a truly static dist/
 RUN npm run generate

--- a/frontend/app/components/layout/AppHeader.vue
+++ b/frontend/app/components/layout/AppHeader.vue
@@ -4,6 +4,7 @@ import HelpdeskFormModal from '~/components/helpdesk/HelpdeskFormModal.vue'
 const authentication = useAuthentication()
 const llmStore = useLLM()
 const router = useRouter()
+const config = useRuntimeConfig()
 const apiKeysOpen = ref(false)
 
 const dropdownItems = computed(() => [
@@ -34,6 +35,9 @@ const dropdownItems = computed(() => [
         <NuxtImg src="/favicon.png" alt="Logo" class="h-10 w-auto object-contain" />
         <h1 class="text-xl font-bold">pix:e</h1>
       </NuxtLink>
+      <div class="text-xs text-neutral-500 self-end mb-2">
+        v{{ config.public.version }}-{{ config.public.gitHash }}
+      </div>
     </template>
 
     <template #right>

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,5 +1,39 @@
 // nuxt.config.ts
 import { defineNuxtConfig } from 'nuxt/config'
+import fs from 'node:fs'
+import path from 'node:path'
+import { execSync } from 'node:child_process'
+
+// Resolve the version safely from the root package.json or environment variables
+let version = process.env.NUXT_PUBLIC_VERSION || process.env.APP_VERSION || '0.0.0'
+
+try {
+  const rootPkgPath = path.resolve(process.cwd(), '../package.json')
+  if (fs.existsSync(rootPkgPath)) {
+    const pkg = JSON.parse(fs.readFileSync(rootPkgPath, 'utf-8'))
+    if (pkg.version) {
+      version = pkg.version
+    }
+  }
+  // Error object not required
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+} catch (_) {
+  console.warn('Could not read root package.json, using fallback version:', version)
+}
+
+// Resolve the Git commit hash (from Env or local git command)
+let gitHash = process.env.NUXT_PUBLIC_GIT_HASH || process.env.COMMIT_HASH || process.env.GITHUB_SHA || ''
+
+if (!gitHash) {
+  try {
+    gitHash = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim()
+  } catch (e) {
+    console.warn('Could not resolve Git commit hash:', e instanceof Error ? e.message : e)
+  }
+}
+
+// Combine version and git hash if available
+const shortGitHash = gitHash ? gitHash.substring(0, 7) : ''
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
@@ -43,7 +77,11 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     apiUrl: process.env.NUXT_API_URL ?? 'http://backend-dev:8000',
-    public: { apiBase: process.env.NUXT_PUBLIC_API_BASE ?? '' },
+    public: {
+      apiBase: process.env.NUXT_PUBLIC_API_BASE ?? '',
+      version: version,
+      gitHash: shortGitHash,
+    },
   },
 
   vite: {

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -22,7 +22,8 @@ try {
 }
 
 // Resolve the Git commit hash (from Env or local git command)
-let gitHash = process.env.NUXT_PUBLIC_GIT_HASH || process.env.COMMIT_HASH || process.env.GITHUB_SHA || ''
+let gitHash =
+  process.env.NUXT_PUBLIC_GIT_HASH || process.env.COMMIT_HASH || process.env.GITHUB_SHA || ''
 
 if (!gitHash) {
   try {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1836,11 +1836,33 @@
         }
       }
     },
+    "node_modules/@nuxt/cli/node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@nuxt/cli/node_modules/citty": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "license": "MIT"
+    },
+    "node_modules/@nuxt/cli/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@nuxt/content": {
       "version": "3.14.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
       },
       "devDependencies": {
         "@iconify-json/lucide": "^1.2.112",
+        "@types/node": "^26.0.1",
         "@vue/eslint-config-prettier": "^10.2.0",
         "prettier": "^3.5.3"
       }
@@ -1835,33 +1836,11 @@
         }
       }
     },
-    "node_modules/@nuxt/cli/node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@nuxt/cli/node_modules/citty": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "license": "MIT"
-    },
-    "node_modules/@nuxt/cli/node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@nuxt/content": {
       "version": "3.14.0",
@@ -6353,6 +6332,16 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/parse-path": {
       "version": "7.0.3",
@@ -18585,6 +18574,13 @@
       "engines": {
         "node": ">=18.12.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@iconify-json/lucide": "^1.2.112",
+    "@types/node": "^26.0.1",
     "@vue/eslint-config-prettier": "^10.2.0",
     "prettier": "^3.5.3"
   },

--- a/infra/docker-compose.override.yml
+++ b/infra/docker-compose.override.yml
@@ -30,6 +30,8 @@ services:
       - ../frontend:/app
       - frontend-node-modules:/app/node_modules
       - frontend-nuxt-cache:/app/.nuxt
+      - ../package.json:/package.json
+      - ../.git:/app/.git
     environment:
       - NUXT_HOST=0.0.0.0
       - HOST=0.0.0.0


### PR DESCRIPTION
# Description

For once, this change adds a small version number to the frontend header bar. Additionally, it also provides a workflow to perform releasing a new version, which includes: 
1. Merging main to the release branch 
2. Change the version inside the root package.json to current release version
3. Push version update with tag to release branch
4. Change the version inside the root package.json to next snapshot version

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested? (How Can The Reviewer Test This?

- [x] Open the web app and check for the version added besides the logo (will be in format v<package.json version>-<git hash>

:information_source: The workflow can only be tested as soon as it has been merged, as github does not know about workflows that are not yet present on the main branch

# Checklist:
- [x] I have performed a self-review of my code
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~ workflow is self documenting, version does not really require documentation - correct me if it requires documentation
- [x] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~ No new tests required
- [x] ~~New and existing unit tests pass locally with my changes~~
- [x] Any dependent changes have been merged and published in downstream modules
