### PR TITLE
StatePx Pathfinding: Reachability Analysis

### DIFF
--- a/frontend/app/composables/usePxChartPathCalculation.ts
+++ b/frontend/app/composables/usePxChartPathCalculation.ts
@@ -22,6 +22,7 @@ export function usePxChartPathCalculation(
     locked: [],
     softLocked: [],
     edgeLocked: [],
+    reachable: [],
   })
 
   const { updateNodeStyling, updateEdgeStyling } = usePxChartPathStyling(
@@ -311,6 +312,7 @@ export function usePxChartPathCalculation(
       )
     }
 
+    result.value.reachable = dist.entries().toArray().filter((id, dist) => dist < Infinity).map(pair => JSON.parse(pair[0]).id)
     result.value.pathEdges = seqEdges.reverse()
     return { path: seq.reverse(), targetState: states.get(targetKeyState) ?? undefined }
   }
@@ -388,6 +390,7 @@ export function usePxChartPathCalculation(
       locked: [],
       softLocked: [],
       edgeLocked: [],
+      reachable: []
     }
     selectedNodes.value = []
   }

--- a/frontend/app/composables/usePxChartPathCalculation.ts
+++ b/frontend/app/composables/usePxChartPathCalculation.ts
@@ -312,7 +312,11 @@ export function usePxChartPathCalculation(
       )
     }
 
-    result.value.reachable = dist.entries().toArray().filter((id, dist) => dist < Infinity).map(pair => JSON.parse(pair[0]).id)
+    result.value.reachable = dist
+      .entries()
+      .toArray()
+      .filter((id, dist) => dist < Infinity)
+      .map((pair) => JSON.parse(pair[0]).id)
     result.value.pathEdges = seqEdges.reverse()
     return { path: seq.reverse(), targetState: states.get(targetKeyState) ?? undefined }
   }
@@ -390,7 +394,7 @@ export function usePxChartPathCalculation(
       locked: [],
       softLocked: [],
       edgeLocked: [],
-      reachable: []
+      reachable: [],
     }
     selectedNodes.value = []
   }

--- a/frontend/app/composables/usePxChartPathCalculationResult.ts
+++ b/frontend/app/composables/usePxChartPathCalculationResult.ts
@@ -6,6 +6,7 @@ export interface PxChartPathCalculationResult {
   locked: string[]
   softLocked: string[]
   edgeLocked: string[]
+  reachable: string[]
 }
 
 export function usePxChartPathCalculationResult(

--- a/frontend/app/composables/usePxChartPathStyling.ts
+++ b/frontend/app/composables/usePxChartPathStyling.ts
@@ -38,10 +38,19 @@ export function usePxChartPathStyling(
       } else if (!result.value.pathNodes.length && selectedNodes.value.includes(node.id)) {
         // use error color for selected nodes when no path connects them
         node.style = getPathStyle('var(--ui-error)')
-      } else if (reachabilityStyling.value === 1 && !result.value.pathNodes.length && result.value.reachable.includes(node.id)) {
+      } else if (
+        reachabilityStyling.value === 1 &&
+        !result.value.pathNodes.length &&
+        result.value.reachable.includes(node.id)
+      ) {
         // use neutral color for (not selected and) reachable nodes when pathfinding fails
         node.style = getPathStyle('var(--ui-neutral)')
-      } else if (reachabilityStyling.value === 2 && selectedNodes.value.length && !result.value.pathNodes.length && !result.value.reachable.includes(node.id)) {
+      } else if (
+        reachabilityStyling.value === 2 &&
+        selectedNodes.value.length &&
+        !result.value.pathNodes.length &&
+        !result.value.reachable.includes(node.id)
+      ) {
         // use error color for unreachable nodes when pathfinding fails
         node.style = getPathStyle('var(--ui-error)')
       } else if (settings.value.show_soft_locks && result.value.softLocked.includes(node.id)) {

--- a/frontend/app/composables/usePxChartPathStyling.ts
+++ b/frontend/app/composables/usePxChartPathStyling.ts
@@ -26,6 +26,10 @@ export function usePxChartPathStyling(
     }
   }
 
+  // version 1: reachable nodes neutral
+  // version 2: unreachable nodes red
+  const reachabilityStyling = ref(2)
+
   async function updateNodeStyling() {
     // set style of nodes in calculated path
     for (const node of nodes.value) {
@@ -33,6 +37,12 @@ export function usePxChartPathStyling(
         node.style = getPathStyle('var(--ui-secondary)')
       } else if (!result.value.pathNodes.length && selectedNodes.value.includes(node.id)) {
         // use error color for selected nodes when no path connects them
+        node.style = getPathStyle('var(--ui-error)')
+      } else if (reachabilityStyling.value === 1 && !result.value.pathNodes.length && result.value.reachable.includes(node.id)) {
+        // use neutral color for (not selected and) reachable nodes when pathfinding fails
+        node.style = getPathStyle('var(--ui-neutral)')
+      } else if (reachabilityStyling.value === 2 && selectedNodes.value.length && !result.value.pathNodes.length && !result.value.reachable.includes(node.id)) {
+        // use error color for unreachable nodes when pathfinding fails
         node.style = getPathStyle('var(--ui-error)')
       } else if (settings.value.show_soft_locks && result.value.softLocked.includes(node.id)) {
         // use info color for nodes with potential soft locks


### PR DESCRIPTION
# Description

This PR adds visualization of (un-)reachable nodes in cases where pathfinding fails. Reachable nodes are identified as those with `dist < Infinity` after the calculation is done. I've thought of two different options for the highlighting, I know which one I'd prefer but wanted to ask for feedback before making a final decision :)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested? (How Can The Reviewer Test This?

- run pathfinding in a chart with known unreachable target node (i chose LA_3 and LA_4 from the user study and selected the start + boss nodes respectively)
   - [x] depending on highlighting version, either all reachable nodes or all unreachable nodes are highlighted

| Case | Version 1: Reachable = gray | Version 2: Unreachable = red |
| --- | --- | --- |
| Majority Reachable | <img width="1170" height="1066" alt="Screenshot from 2026-07-17 15-02-26" src="https://github.com/user-attachments/assets/b12490ab-4525-4140-8d4a-3a571ab78fad" /> | <img width="1076" height="1009" alt="image" src="https://github.com/user-attachments/assets/d55189f7-c26b-49e5-8265-c8671ed74c32" /> |
| Majority Unreachable | <img width="1473" height="882" alt="image" src="https://github.com/user-attachments/assets/bfc8d10d-73e4-4319-b7d4-8f4168914056" /> | <img width="1473" height="882" alt="Screenshot from 2026-07-17 15-21-19" src="https://github.com/user-attachments/assets/f6048fd9-33a5-4dc0-9e43-afe8fca5c5d9" /> |

> [!NOTE]
> I think I prefer version 2, as it draws more attention to the problem areas (unreachable nodes). Also, then we wouldn't introduce yet another highlighting color. On the other hand, some users (probably more technical people?) may intuitively ask the question "which nodes are reachable?", to which version 1 caters more.

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
