### PR TITLE
eval: multi-model harness, CP strategy refinements + Pokémon dataset seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ backend/docs/experiments/*
 backend/db_backup_20260104_125924.sql
 backend/vectors.db
 backend/artifacts/*
+# secrets (never commit)
+.env
+cookies.txt

--- a/backend/llm/providers/manager.py
+++ b/backend/llm/providers/manager.py
@@ -11,6 +11,7 @@ Central manager that handles:
 """
 
 import logging
+import os
 import time
 from typing import Any, Dict, List, Optional, Tuple, cast
 
@@ -84,11 +85,19 @@ class ModelManager:
 
         if self.config.openai_api_key:
             try:
+                # Eval-only: an OPENAI_BASE_URL env var routes the OpenAI-compatible
+                # client to a custom endpoint (e.g. OpenRouter) and, when set, keeps
+                # all model ids (not just gpt-*) so non-OpenAI slugs resolve. No
+                # effect in normal operation (env var unset -> base_url None,
+                # include_all_models False).
+                _openai_base_url = os.getenv("OPENAI_BASE_URL") or None
                 openai = OpenAIProvider(
                     {
                         "api_key": self.config.openai_api_key,
                         "organization": self.config.openai_organization,
                         "timeout": self.config.openai_timeout_seconds,
+                        "base_url": _openai_base_url,
+                        "include_all_models": bool(_openai_base_url),
                     }
                 )
                 if openai.is_available():

--- a/backend/pxnodes/llm/agents/change_propagation/workflow.py
+++ b/backend/pxnodes/llm/agents/change_propagation/workflow.py
@@ -55,7 +55,7 @@ class ChangePropagationWorkflow:
         findings: List[PropagationFinding] = []
         try:
             if use_graph_context:
-                findings = self._run_iterative_graph_propagation(
+                findings = self._run_graph_propagation(
                     project=project,
                     changed_node=changed_node,
                     old_description=old_description,
@@ -280,7 +280,7 @@ class ChangePropagationWorkflow:
             if nid in nodes_by_id
         ]
 
-    def _run_iterative_graph_propagation(
+    def _run_graph_propagation(
         self,
         project: Project,
         changed_node: PxNode,
@@ -290,6 +290,16 @@ class ChangePropagationWorkflow:
         max_depth: int,
         model_id: Optional[str] = None,
     ) -> List[PropagationFinding]:
+        """Graph-aware retrieval in retrieve-then-judge form.
+
+        Collect the changed node's chart neighbourhood up to ``max_depth`` hops with
+        a pure BFS over PxChartEdge (no LLM), then judge that whole candidate set in a
+        *single* LLM pass. This mirrors the flat and semantic arms (retrieve a
+        candidate set, then one call) and differs only in *how* the set is
+        retrieved — graph neighbourhood vs. all nodes vs. embedding top-k. Cost is one
+        call per change at any depth, so it scales to dense dependency graphs, unlike
+        an iterative per-hop expansion (one call per expanded node) which cascades.
+        """
         assert self._model_manager is not None
         agent = ChangePropagationAgent(
             model_manager=self._model_manager,
@@ -297,14 +307,11 @@ class ChangePropagationWorkflow:
             model_id=model_id,
         )
 
-        all_findings: Dict[str, PropagationFinding] = {}
-        visited: Set[str] = {str(changed_node.id)}
-
-        # Round 1: direct 1-hop neighbors of the changed node
-        neighbors = self._get_1hop_neighbors(changed_node.id)
-        if neighbors is None:
+        # A node not placed in any chart has no neighbourhood → fall back to flat.
+        first_hop = self._get_1hop_neighbors(changed_node.id)
+        if first_hop is None:
             logger.warning(
-                "[BFS] Node '%s' not in any chart — falling back to flat list.",
+                "[graph] Node '%s' not in any chart — falling back to flat list.",
                 changed_node.name,
             )
             other_nodes = list(project.pxnodes.exclude(id=changed_node.id))
@@ -316,77 +323,38 @@ class ChangePropagationWorkflow:
                 use_graph_context=False,
             )
 
-        if not neighbors:
-            logger.warning("[BFS] Node '%s' has no graph neighbors.", changed_node.name)
-            return []
-
-        logger.warning(
-            "[BFS] Round 1: %d neighbors of '%s'",
-            len(neighbors),
-            changed_node.name,
-        )
-
-        round1_findings = agent.analyze_change(
-            changed_node=changed_node,
-            old_description=old_description,
-            new_description=new_description,
-            other_nodes=neighbors,
-            use_graph_context=True,
-        )
-
-        frontier: List[PropagationFinding] = []
-        for f in round1_findings:
-            nid = f.affected_node_id
-            visited.add(nid)
-            all_findings[nid] = f
-            frontier.append(f)
-
-        # Rounds 2..max_depth
-        for depth in range(2, max_depth + 1):
+        # BFS to max_depth, collecting the neighbourhood as candidate dicts.
+        visited: Set[str] = {str(changed_node.id)}
+        collected: Dict[str, Dict[str, Any]] = {}
+        frontier: List[Any] = [changed_node.id]
+        for _ in range(max_depth):
+            next_frontier: List[Any] = []
+            for nid in frontier:
+                for nb in self._get_1hop_neighbors(nid) or []:
+                    if nb["id"] not in visited:
+                        visited.add(nb["id"])
+                        collected[nb["id"]] = nb
+                        next_frontier.append(nb["id"])
+            frontier = next_frontier
             if not frontier:
                 break
 
-            next_frontier: List[PropagationFinding] = []
-            for parent_finding in frontier:
-                parent_id = parent_finding.affected_node_id
-                parent_neighbors = self._get_1hop_neighbors(parent_id)
-                if not parent_neighbors:
-                    continue
+        if not collected:
+            logger.warning(
+                "[graph] Node '%s' has no graph neighbours.", changed_node.name
+            )
+            return []
 
-                unseen = [n for n in parent_neighbors if n["id"] not in visited]
-                if not unseen:
-                    continue
-
-                logger.warning(
-                    "[BFS] Round %d: expanding '%s' → %d unseen neighbors",
-                    depth,
-                    parent_finding.affected_node_name,
-                    len(unseen),
-                )
-
-                try:
-                    parent_node = PxNode.objects.get(id=parent_id)
-                except PxNode.DoesNotExist:
-                    continue
-
-                new_findings = agent.analyze_transitive_change(
-                    changed_node_name=changed_node.name,
-                    old_description=old_description,
-                    new_description=new_description,
-                    affected_node_name=parent_node.name,
-                    affected_node_description=parent_node.description or "",
-                    reason_chain=parent_finding.reason,
-                    neighbors=unseen,
-                )
-
-                for f in new_findings:
-                    nid = f.affected_node_id
-                    visited.add(nid)
-                    if nid not in all_findings:
-                        all_findings[nid] = f
-                        next_frontier.append(f)
-
-            frontier = next_frontier
-
-        logger.warning("[BFS] Done. Total findings: %d", len(all_findings))
-        return list(all_findings.values())
+        logger.warning(
+            "[graph] '%s': %d-node neighbourhood within %d hop(s), single LLM pass.",
+            changed_node.name,
+            len(collected),
+            max_depth,
+        )
+        return agent.analyze_change(
+            changed_node=changed_node,
+            old_description=old_description,
+            new_description=new_description,
+            other_nodes=list(collected.values()),
+            use_graph_context=True,
+        )

--- a/backend/pxnodes/llm/eval/consistency_runner.py
+++ b/backend/pxnodes/llm/eval/consistency_runner.py
@@ -14,7 +14,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 from llm.providers.manager import ModelManager
 from projects.models import Project
@@ -95,6 +95,33 @@ def load_traps(path: str | Path, layer: str) -> List[Trap]:
     return traps
 
 
+class _CountingModelManager(ModelManager):
+    """Wraps ModelManager to tally LLM calls and token usage for feasibility
+    reporting, mirroring the change-propagation harness."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.n_calls = 0
+        self.prompt_tokens = 0
+        self.completion_tokens = 0
+
+    def _tally(self, result: Any) -> Any:
+        self.n_calls += 1
+        self.prompt_tokens += getattr(result, "prompt_tokens", 0) or 0
+        self.completion_tokens += getattr(result, "completion_tokens", 0) or 0
+        return result
+
+    def generate_structured_with_model(self, *args: Any, **kwargs: Any) -> Any:
+        return self._tally(super().generate_structured_with_model(*args, **kwargs))
+
+    async def generate_structured_with_model_async(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:
+        return self._tally(
+            await super().generate_structured_with_model_async(*args, **kwargs)
+        )
+
+
 @dataclass
 class ConsistencyEvalReport:
     layer: str
@@ -104,6 +131,9 @@ class ConsistencyEvalReport:
     run_results: List[RunResult] = field(default_factory=list)
     raw_findings: List[List[dict]] = field(default_factory=list)
     durations_s: List[float] = field(default_factory=list)
+    n_calls: List[int] = field(default_factory=list)
+    prompt_tokens: List[int] = field(default_factory=list)
+    completion_tokens: List[int] = field(default_factory=list)
     metrics: Optional[AggregateMetrics] = None
 
 
@@ -139,8 +169,9 @@ def run_consistency_eval(
         # A transient API failure (e.g. rate limit) on one run must not discard
         # all the others — record only successful runs and carry on.
         try:
+            mm = _CountingModelManager() if needs_model else None
             workflow = ConsistencyWorkflow(
-                model_manager=ModelManager() if needs_model else None,
+                model_manager=mm,
                 min_confidence=min_confidence,
                 run_structural=run_structural,
                 model_id=model_id,
@@ -150,6 +181,10 @@ def run_consistency_eval(
             start = time.perf_counter()
             result = workflow.check_project(project)
             report.durations_s.append(time.perf_counter() - start)
+            if mm is not None:
+                report.n_calls.append(mm.n_calls)
+                report.prompt_tokens.append(mm.prompt_tokens)
+                report.completion_tokens.append(mm.completion_tokens)
 
             raw = [
                 {

--- a/backend/pxnodes/llm/eval/metrics.py
+++ b/backend/pxnodes/llm/eval/metrics.py
@@ -89,7 +89,9 @@ class RunResult:
         return 2 * p * r / (p + r) if (p + r) else 0.0
 
 
-def _trap_matches(finding: Finding, trap: Trap) -> bool:
+def _trap_matches(
+    finding: Finding, trap: Trap, strict_pairs: bool = False
+) -> bool:
     if finding.category != trap.category:
         return False
     if trap.node is None:
@@ -98,23 +100,38 @@ def _trap_matches(finding: Finding, trap: Trap) -> bool:
     trap_names = {trap.node}
     if trap.partner:
         trap_names.add(trap.partner)
-    # A pairwise finding implicates two nodes; match if EITHER side of the
-    # finding (node_A via entity_id, or node_B via the message) is in the trap.
+    # A pairwise finding implicates two nodes (node_A via entity_id, node_B via
+    # the message). The default (loose) rule matches if EITHER side coincides
+    # with the trap, so a genuine detection is not missed merely because the two
+    # nodes were named in the opposite order. The optional strict rule requires
+    # BOTH nodes of a pairwise trap (an unordered exact pair), used for the
+    # robustness check in the evaluation.
     finding_names = {
         name for name in (finding.resolved_name, finding.partner_name) if name
     }
+    if strict_pairs and trap.partner:
+        return trap_names <= finding_names
     return bool(trap_names & finding_names)
 
 
-def match_run(findings: Sequence[Finding], traps: Sequence[Trap]) -> RunResult:
-    """Match one run's findings against the trap set (greedy, each trap once)."""
+def match_run(
+    findings: Sequence[Finding],
+    traps: Sequence[Trap],
+    strict_pairs: bool = False,
+) -> RunResult:
+    """Match one run's findings against the trap set (greedy, each trap once).
+
+    With ``strict_pairs=True`` a pairwise trap is credited only when a finding
+    names *both* its nodes (unordered), rather than either one; used for the
+    matching-robustness check reported in the evaluation.
+    """
     result = RunResult(fn=list(traps))
     unmatched = list(traps)
 
     for finding in findings:
         matched: Optional[Trap] = None
         for trap in unmatched:
-            if _trap_matches(finding, trap):
+            if _trap_matches(finding, trap, strict_pairs):
                 matched = trap
                 break
         if matched is not None:

--- a/backend/pxnodes/llm/eval/metrics.py
+++ b/backend/pxnodes/llm/eval/metrics.py
@@ -89,9 +89,7 @@ class RunResult:
         return 2 * p * r / (p + r) if (p + r) else 0.0
 
 
-def _trap_matches(
-    finding: Finding, trap: Trap, strict_pairs: bool = False
-) -> bool:
+def _trap_matches(finding: Finding, trap: Trap, strict_pairs: bool = False) -> bool:
     if finding.category != trap.category:
         return False
     if trap.node is None:

--- a/backend/pxnodes/llm/eval/tests/test_metrics.py
+++ b/backend/pxnodes/llm/eval/tests/test_metrics.py
@@ -113,9 +113,9 @@ class TestStrictPairMatching:
 
     def test_strict_ignores_pair_order(self):
         swapped = self._pair_finding("Y", "X")
-        assert [
-            t.id for t in match_run([swapped], [C1], strict_pairs=True).tp
-        ] == ["C1"]
+        assert [t.id for t in match_run([swapped], [C1], strict_pairs=True).tp] == [
+            "C1"
+        ]
 
     def test_strict_leaves_single_node_traps_unchanged(self):
         # Non-pairwise traps (no partner) behave identically under strict.

--- a/backend/pxnodes/llm/eval/tests/test_metrics.py
+++ b/backend/pxnodes/llm/eval/tests/test_metrics.py
@@ -88,6 +88,45 @@ class TestMatchRun:
         assert len(res.fp) == 1
 
 
+class TestStrictPairMatching:
+    """Robustness rule: a pairwise trap needs BOTH nodes (unordered)."""
+
+    def _pair_finding(self, node_a, node_b):
+        return Finding(
+            category="node_contradiction",
+            entity_id="id-a",
+            resolved_name=node_a,
+            partner_name=node_b,
+        )
+
+    def test_strict_requires_both_pair_nodes(self):
+        # Only one side (partner Y) named: matches loose, misses strict.
+        one_side = self._pair_finding("Some Other Node", "Y")
+        assert [t.id for t in match_run([one_side], [C1]).tp] == ["C1"]
+        strict = match_run([one_side], [C1], strict_pairs=True)
+        assert strict.tp == []
+        assert [t.id for t in strict.fn] == ["C1"]
+
+    def test_strict_matches_when_both_nodes_named(self):
+        both = self._pair_finding("X", "Y")
+        assert [t.id for t in match_run([both], [C1], strict_pairs=True).tp] == ["C1"]
+
+    def test_strict_ignores_pair_order(self):
+        swapped = self._pair_finding("Y", "X")
+        assert [
+            t.id for t in match_run([swapped], [C1], strict_pairs=True).tp
+        ] == ["C1"]
+
+    def test_strict_leaves_single_node_traps_unchanged(self):
+        # Non-pairwise traps (no partner) behave identically under strict.
+        assert [
+            t.id
+            for t in match_run(
+                [_f("pillar_misalignment", "A")], [P1], strict_pairs=True
+            ).tp
+        ] == ["P1"]
+
+
 class TestAggregate:
     def test_precision_recall_f1_single_run(self):
         res = match_run([_f("pillar_misalignment", "A")], [P1, T1])

--- a/backend/pxnodes/management/commands/rescore_consistency_eval.py
+++ b/backend/pxnodes/management/commands/rescore_consistency_eval.py
@@ -34,6 +34,15 @@ class Command(BaseCommand):
         parser.add_argument("--results", type=str, required=True)
         parser.add_argument("--dataset", type=str, required=True)
         parser.add_argument("--ground-truth", type=str, default=str(_DEFAULT_GT))
+        parser.add_argument(
+            "--strict-pairs",
+            action="store_true",
+            help=(
+                "Credit a pairwise trap only when a finding names BOTH its "
+                "nodes (unordered exact pair) instead of either side. Used for "
+                "the matching-robustness check."
+            ),
+        )
 
     def handle(self, *args, **options):
         for key in ("results", "dataset"):
@@ -44,9 +53,11 @@ class Command(BaseCommand):
         dataset = json.loads(Path(options["dataset"]).read_text())
         node_map = {str(n["id"]): n["name"] for n in dataset["pxnodes"]}
 
+        strict = options["strict_pairs"]
         self.stdout.write(
             f"Re-scoring {Path(options['results']).name} "
-            f"({len(node_map)} nodes in dataset)\n"
+            f"({len(node_map)} nodes in dataset)"
+            f"{'  [strict unordered-pair matching]' if strict else ''}\n"
         )
 
         for layer, payload in results.get("layers", {}).items():
@@ -61,7 +72,7 @@ class Command(BaseCommand):
                     to_finding(f["category"], f["entity_id"], f["message"], node_map)
                     for f in raw
                 ]
-                run_results.append(match_run(findings, traps))
+                run_results.append(match_run(findings, traps, strict_pairs=strict))
 
             m = aggregate(run_results, traps)
             self.stdout.write(

--- a/backend/pxnodes/management/commands/run_consistency_eval.py
+++ b/backend/pxnodes/management/commands/run_consistency_eval.py
@@ -184,6 +184,9 @@ class Command(BaseCommand):
             "avg_false_positives": m.avg_false_positives,
             "avg_hallucinations": m.avg_hallucinations,
             "durations_s": report.durations_s,
+            "n_calls": report.n_calls,
+            "prompt_tokens": report.prompt_tokens,
+            "completion_tokens": report.completion_tokens,
             "per_run": [
                 {
                     "tp": [t.id for t in r.tp],

--- a/backend/pxnodes/management/commands/seed_pokemon_dataset.py
+++ b/backend/pxnodes/management/commands/seed_pokemon_dataset.py
@@ -1,0 +1,139 @@
+"""Seed a structured eval-dataset JSON (pillars + nodes + optional components)
+into an EXISTING pix:e project via the ORM.
+
+Unlike ``pxnodes/llm/eval/loader.py`` (which loads a fully *frozen* export incl.
+charts/containers/edges into a throwaway eval project), this seeds only the
+*content* — pillars, nodes, and optional component values — into a real project
+you created in the tool. The chart graph (edges) is then drawn by hand in the UI,
+and the whole thing is frozen with ``export_eval_dataset``.
+
+Input JSON schema:
+    {
+      "pillars": [{"name": "...", "description": "..."}],
+      "component_definitions": [{"name": "Recommended Level", "type": "number"}],
+      "nodes": [
+        {"name": "...", "description": "...",
+         "components": {"Recommended Level": 13, "Gym Type": "Rock"}}
+      ]
+    }
+(`type` ∈ {"number", "string", "boolean"}; "components" is optional.)
+
+Usage:
+    python manage.py seed_pokemon_dataset \\
+        --project-id 7 \\
+        --input ~/Documents/thesis/bachelorarbeit/pokemon_kanto_seed.json \\
+        [--wipe]
+
+IMPORTANT: run this in the SAME environment as the running app (e.g. inside the
+docker container if the UI runs via docker) so it writes to the DB the browser
+reads — otherwise the seeded nodes won't show up in your project.
+"""
+
+import json
+import uuid
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from pillars.models import Pillar
+from projects.models import Project
+from pxnodes.models import PxComponent, PxComponentDefinition, PxNode
+
+
+class Command(BaseCommand):
+    help = "Seed pillars + nodes (+ components) from JSON into an existing project."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--project-id", type=int, required=True)
+        parser.add_argument("--input", type=str, required=True)
+        parser.add_argument(
+            "--wipe",
+            action="store_true",
+            help="Delete the project's existing pillars/defs/nodes before seeding.",
+        )
+
+    def handle(self, *args, **options):
+        path = Path(options["input"]).expanduser()
+        if not path.exists():
+            raise CommandError(f"Input not found: {path}")
+        data = json.loads(path.read_text())
+
+        try:
+            project = Project.objects.get(id=options["project_id"])
+        except Project.DoesNotExist:
+            raise CommandError(f"Project {options['project_id']} not found")
+        user = project.user
+
+        pillars = data.get("pillars", [])
+        defs = data.get("component_definitions", [])
+        nodes = data.get("nodes", [])
+
+        with transaction.atomic():
+            if options["wipe"]:
+                d1 = Pillar.objects.filter(project=project).delete()[0]
+                d2 = PxComponentDefinition.objects.filter(project=project).delete()[0]
+                d3 = PxNode.objects.filter(project=project).delete()[0]
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Wiped existing pillars/defs/nodes: {d1}/{d2}/{d3}"
+                    )
+                )
+
+            for p in pillars:
+                Pillar.objects.create(
+                    user=user,
+                    project=project,
+                    name=p["name"],
+                    description=p.get("description", ""),
+                )
+
+            # PxComponentDefinition / PxNode / PxComponent use UUID primary keys
+            # with no default — the id must be supplied explicitly (mirrors
+            # loader.py). Pillar uses an auto integer PK, so it needs no id.
+            def_by_name = {}
+            for d in defs:
+                def_by_name[d["name"]] = PxComponentDefinition.objects.create(
+                    id=uuid.uuid4(),
+                    name=d["name"],
+                    type=d["type"],
+                    owner=user,
+                    project=project,
+                )
+
+            n_nodes = n_comp = 0
+            for n in nodes:
+                node = PxNode.objects.create(
+                    id=uuid.uuid4(),
+                    name=n["name"],
+                    description=n.get("description", ""),
+                    owner=user,
+                    project=project,
+                )
+                n_nodes += 1
+                for cname, cval in (n.get("components") or {}).items():
+                    defn = def_by_name.get(cname)
+                    if defn is None:
+                        self.stdout.write(
+                            self.style.WARNING(
+                                f"  node '{n['name']}': unknown component "
+                                f"'{cname}' — skipped"
+                            )
+                        )
+                        continue
+                    PxComponent.objects.create(
+                        id=uuid.uuid4(),
+                        node=node,
+                        definition=defn,
+                        value=cval,
+                        owner=user,
+                    )
+                    n_comp += 1
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Seeded into project {project.id} ('{project.name}'): "
+                f"{len(pillars)} pillars, {len(defs)} component defs, "
+                f"{n_nodes} nodes, {n_comp} components."
+            )
+        )

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -3,7 +3,7 @@ isort==6.0.1
 flake8==7.2.0
 mypy==1.18.2
 mypy_extensions==1.1.0
-Django>=5.2.14
+Django>=5.2.14,<6.0
 django-cors-headers==4.9.0
 django-stubs==5.1.3
 django-stubs-ext==5.2.7

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.10.0
 cryptography==44.0.3
-Django>=5.2.14
+Django>=5.2.14,<6.0
 django-cors-headers==4.9.0
 djangorestframework==3.16.1
 drf-nested-routers==0.94.2


### PR DESCRIPTION
# Description

  Builds on #183. Adds the evaluation refinements and tooling used to produce the
  thesis results, plus a small dependency fix so CI passes.

  **Backend / agents**
  - Multi-model + local execution: base-URL override in `ModelManager` so the agents
    run across GPT, Claude and Llama (OpenAI-compatible / OpenRouter) and a local
    Ollama model, with no per-provider code.
  - Change-propagation `workflow.py` refinements for the graph-aware, semantic (RAG),
    pairwise and neighbours strategies.

  **Evaluation harness**
  - Matching & metrics module (`metrics.py`) — Django-free, unit-tested.
  - Consistency runner and the `run_consistency_eval` / `rescore_consistency_eval`
    management commands (re-score a saved run without re-invoking any model).
  - `seed_pokemon_dataset` management command (seeds pillars/nodes/components into a
    project via the ORM).

  **Dependencies**
  - Cap `Django>=5.2.14,<6.0` in both `requirements.txt` and `requirements-dev.txt`:
    Django 6 removed `django.utils.cache.cc_delim_re`, which DRF 3.16.1 still imports,
    so an uncapped `>=5.2.14` made CI pull Django 6.1 and fail at import. (Note: the
    same uncapped pin exists on `main` and should be capped there too.)

  Note: the frozen datasets / ground-truth JSONs are intentionally not included
  (copyrighted game content); they are provided separately.

  Depends on: #183

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

  # How Has This Been Tested?

  All backend CI steps were run locally, and the previously-failing steps were
  re-verified in a fresh virtualenv installed exactly like CI (`pip install -r
  requirements-dev.txt`, which resolves to Django 5.2.17 with the cap):

  - [x] Lint/type: `black --check .`, `isort --check-only .`, `flake8 .`, `mypy .` — all clean.
  - [x] Eval unit tests: `pytest pxnodes/llm/eval/tests/test_metrics.py` — 19 passed.
  - [x] Full CI test suite: `pytest llm/tests/ pillars/tests/ accounts/tests.py` — 142 passed.
  - [x] Django checks: `makemigrations --check --dry-run` — "No changes detected".

  **Test Configuration**:
  * Python: 3.12 (CI) / 3.13 (local)
  * DRF: 3.16.1
  * Test runner: pytest 8.4 + pytest-django 4.9
  
  # Checklist:
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [ ] Any dependent changes have been merged and published in downstream modules